### PR TITLE
User object in security token can be empty

### DIFF
--- a/EventListener/RollbarListener.php
+++ b/EventListener/RollbarListener.php
@@ -149,6 +149,9 @@ class RollbarListener
         if ($this->securityContext->getToken() && $this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             $userData = array();
             $user = $this->securityContext->getToken()->getUser();
+            if (!$user) {
+                return null;
+            }
             if (method_exists($user, 'getId')) {
                 $userData['id'] = $user->getId();
             } else {


### PR DESCRIPTION
For example, authenticated with an application access token with FOSOAuthServerBundle.
