### PR TITLE
Voter service for report decision

### DIFF
--- a/DependencyInjection/CompilerPass/RegisterDecisionVoterPass.php
+++ b/DependencyInjection/CompilerPass/RegisterDecisionVoterPass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Staffim\RollbarBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterDecisionVoterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('staffim_rollbar.report_decision_manager')) {
+            return;
+        }
+
+        $voters = array();
+        foreach ($container->findTaggedServiceIds('staffim_rollbar.report_voter') as $id => $tags) {
+            foreach ($tags as $tag) {
+                $voters[] = new Reference($id);
+            }
+        }
+
+        $container
+            ->getDefinition('staffim_rollbar.report_decision_manager')
+            ->replaceArgument(0, $voters)
+        ;
+    }
+}

--- a/DependencyInjection/StaffimRollbarExtension.php
+++ b/DependencyInjection/StaffimRollbarExtension.php
@@ -32,5 +32,13 @@ class StaffimRollbarExtension extends Extension
             $container->setParameter('staffim_rollbar.scrub_parameters', $config['scrub']['parameters']);
             $container->setParameter('staffim_rollbar.notify_http_exception', $config['notify_http_exception']);
         }
+
+        if ($config['notify_http_exception']) {
+            $container->removeDefinition('staffim_rollbar.http_exception_voter');
+        }
+
+        if (!$container->hasDefinition('request_stack')) {
+            $container->removeDefinition('staffim_rollbar.same_referer_voter');
+        }
     }
 }

--- a/ReportDecisionManager.php
+++ b/ReportDecisionManager.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Staffim\RollbarBundle;
+
+use Exception;
+
+class ReportDecisionManager
+{
+    private $voters;
+
+    public function __construct(array $voters)
+    {
+        $this->voters = $voters;
+    }
+
+    public function decide($exception, array $context = array())
+    {
+        foreach ($this->voters as $voter) {
+            if (!$voter->vote($exception, $context)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,6 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="staffim_rollbar.rollbar_listener.class">Staffim\RollbarBundle\EventListener\RollbarListener</parameter>
+        <parameter key="staffim_rollbar.default_report_voter.class">Staffim\RollbarBundle\Voter\DefaultReportVoter</parameter>
+        <parameter key="staffim_rollbar.report_decision_manager.class">Staffim\RollbarBundle\ReportDecisionManager</parameter>
+        <parameter key="staffim_rollbar.http_exception_voter.class">Staffim\RollbarBundle\Voter\HttpExceptionVoter</parameter>
+        <parameter key="staffim_rollbar.same_referer_voter.class">Staffim\RollbarBundle\Voter\SameRefererVoter</parameter>
         <parameter key="staffim_rollbar.rollbar.class">RollbarNotifier</parameter>
         <parameter key="staffim_rollbar.rollbar.access_token"></parameter>
         <parameter key="staffim_rollbar.rollbar.error_level">-1</parameter>
@@ -14,6 +18,7 @@
         <service id="staffim_rollbar.rollbar_listener" class="%staffim_rollbar.rollbar_listener.class%">
             <argument type="service" id="staffim_rollbar.rollbar"/>
             <argument type="service" id="security.context"/>
+            <argument type="service" id="staffim_rollbar.report_decision_manager"/>
             <argument>%staffim_rollbar.rollbar.error_level%</argument>
             <argument>%staffim_rollbar.scrub_exceptions%</argument>
             <argument>%staffim_rollbar.scrub_parameters%</argument>
@@ -22,8 +27,26 @@
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-200" />
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
         </service>
+
         <service id="staffim_rollbar.rollbar" class="%staffim_rollbar.rollbar.class%">
             <argument>%staffim_rollbar.rollbar.arguments%</argument>
+        </service>
+
+        <service id="staffim_rollbar.default_report_voter" class="%staffim_rollbar.default_report_voter.class%">
+            <argument>%staffim_rollbar.notify_http_exception%</argument>
+        </service>
+
+        <service id="staffim_rollbar.report_decision_manager" class="%staffim_rollbar.report_decision_manager.class%">
+            <argument />
+        </service>
+
+        <service id="staffim_rollbar.http_exception_voter" class="%staffim_rollbar.http_exception_voter.class%">
+            <tag name="staffim_rollbar.report_voter" />
+        </service>
+
+        <service id="staffim_rollbar.same_referer_voter" class="%staffim_rollbar.same_referer_voter.class%">
+            <argument type="service" id="request_stack" />
+            <tag name="staffim_rollbar.report_voter" />
         </service>
     </services>
 </container>

--- a/StaffimRollbarBundle.php
+++ b/StaffimRollbarBundle.php
@@ -1,6 +1,8 @@
 <?php
 namespace Staffim\RollbarBundle;
 
+use Staffim\RollbarBundle\DependencyInjection\CompilerPass\RegisterDecisionVoterPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -8,5 +10,13 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class StaffimRollbarBundle extends Bundle
 {
-}
+    /**
+     * {@inheritDoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new RegisterDecisionVoterPass());
+    }
+}

--- a/Voter/HttpExceptionVoter.php
+++ b/Voter/HttpExceptionVoter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Staffim\RollbarBundle\Voter;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class HttpExceptionVoter implements ReportVoterInterface
+{
+    private function support($exception)
+    {
+        return $exception instanceof HttpException;
+    }
+
+    public function vote($exception)
+    {
+        return !$this->support($exception);
+    }
+}

--- a/Voter/ReportVoterInterface.php
+++ b/Voter/ReportVoterInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Staffim\RollbarBundle\Voter;
+
+interface ReportVoterInterface
+{
+    public function vote($exception);
+}

--- a/Voter/SameRefererVoter.php
+++ b/Voter/SameRefererVoter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Staffim\RollbarBundle\Voter;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class SameRefererVoter implements ReportVoterInterface
+{
+    private $requestStack;
+
+    public function __construct($requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    private function support($exception)
+    {
+        return $exception instanceof NotFoundHttpException &&
+            null !== $this->requestStack->getCurrentRequest()
+        ;
+    }
+
+    public function vote($exception)
+    {
+        if (!$this->support($exception)) {
+            return true;
+        }
+
+        return $this->sameRefererRequest();
+    }
+
+    public function sameRefererRequest()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        $referer = parse_url($request->server->get('HTTP_REFERER'), PHP_URL_HOST);
+
+        return $referer === $request->getHost();
+    }
+}


### PR DESCRIPTION
I have created 2 voters:

 - HttpExceptionVoter to avoid HttpException notification
 - SameRefererVoter to avoid NotFoundHttpException notification if the HTTP_REFERER and the HTTP_HOST are not equals. Symfony 2.4+ as we need the request_stack.

Fix #7