### PR TITLE
Introduce a RollbarReporter class

### DIFF
--- a/EventListener/RollbarListener.php
+++ b/EventListener/RollbarListener.php
@@ -1,123 +1,37 @@
 <?php
 namespace Staffim\RollbarBundle\EventListener;
 
-use ErrorException;
 use Exception;
-use Staffim\RollbarBundle\ReportDecisionManager;
-use Staffim\RollbarBundle\Voter\ReportVoterInterface;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
-use Symfony\Component\Debug\Exception\FlattenException;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * @author Vyacheslav Salakhutdinov <megazoll@gmail.com>
  */
-class RollbarListener
+class RollbarListener implements EventSubscriberInterface
 {
-    /**
-     * @var \RollbarNotifier
-     */
-    private $rollbarNotifier;
+    private $exceptionReporter;
 
-    /**
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
-     */
-    private $securityContext;
-
-    /**
-     * @var int
-     */
-    private $errorLevel;
-
-    /**
-     * @var \Exception
-     */
-    private $exception;
-
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    private $request;
-
-    /**
-     * @var \Staffim\RollbarBundle\ReportVoterInterface
-     */
-    private $reportVoter;
-
-    /**
-     * @var callable
-     */
-    private $previousErrorHandler;
-
-    private $scrubExceptions;
-
-    private $scrubParameters;
-
-
-    /**
-     * Constructor.
-     *
-     * @param \RollbarNotifier $rollbarNotifier
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext
-     * @param int $errorLevel
-     * @param array $scrubExceptions
-     * @param array $scrubParameters
-     */
-    public function __construct(
-        \RollbarNotifier $rollbarNotifier,
-        SecurityContextInterface $securityContext,
-        ReportDecisionManager $reportDecisionManager,
-        $errorLevel = null,
-        array $scrubExceptions = array(),
-        array $scrubParameters = array()
-    ) {
-        $this->rollbarNotifier = $rollbarNotifier;
-        $this->securityContext = $securityContext;
-        $this->reportDecisionManager = $reportDecisionManager;
-        $this->setErrorLevel($errorLevel);
-        $this->scrubExceptions = $scrubExceptions;
-        $this->scrubParameters = $scrubParameters;
-
-        $this->rollbarNotifier->person_fn = array($this, 'getUserData');
-        register_shutdown_function(array($this, 'flush'));
-        $this->previousErrorHandler = set_error_handler(array($this, 'handleError'));
-    }
-
-    /**
-     * Return RollbarNotifier instance.
-     *
-     * @return \RollbarNotifier
-     */
-    public function getRollbarNotifier()
+    public function __construct($exceptionReporter)
     {
-        return $this->rollbarNotifier;
+        $this->exceptionReporter = $exceptionReporter;
     }
 
-    /**
-     * Set error level.
-     *
-     * @param type $errorLevel
-     */
-    public function setErrorLevel($errorLevel)
+    public static function getSubscribedEvents()
     {
-        $this->errorLevel = is_null($errorLevel) ? error_reporting() : $errorLevel;
+        return array(
+            KernelEvents::EXCEPTION => array('onKernelException', -100),
+            KernelEvents::TERMINATE => array('onKernelTerminate', -100),
+            ConsoleEvents::EXCEPTION => array('onConsoleException', -100),
+            ConsoleEvents::TERMINATE => array('onConsoleTerminate', -100),
+        );
     }
 
     /**
-     * Set request.
-     *
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
-     */
-    public function onKernelRequest(GetResponseEvent $event)
-    {
-        $this->request = $event->getRequest();
-    }
-
-    /**
-     * Log kernel exception.
+     * Report kernel exception.
      *
      * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
      */
@@ -125,29 +39,11 @@ class RollbarListener
     {
         $exception = $event->getException();
 
-        return $this->handleException($exception);
+        return $this->exceptionReporter->report($exception);
     }
 
     /**
-     * Wrap exception with additional info.
-     *
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
-     */
-    public function onKernelResponse(FilterResponseEvent $event)
-    {
-        if ($this->exception) {
-            $debugToken = $event->getResponse()->headers->get('X-Debug-Token');
-            $_SERVER['HTTP_DEBUG_TOKEN'] = $debugToken;
-            $_SERVER['HTTP_REQUEST_CONTENT'] = $event->getRequest()->getContent();
-            $this->rollbarNotifier->report_exception($this->exception);
-            unset($_SERVER['HTTP_DEBUG_TOKEN']);
-            unset($_SERVER['HTTP_REQUEST_CONTENT']);
-            $this->exception = null;
-        }
-    }
-
-    /**
-     * Log console exception.
+     * Report console exception.
      *
      * @param \Symfony\Component\Console\Event\ConsoleExceptionEvent $event
      */
@@ -155,115 +51,22 @@ class RollbarListener
     {
         $exception = $event->getException();
 
-        return $this->handleException($exception);
+        return $this->exceptionReporter->report($exception);
     }
 
     /**
-     * Handle exception with voters and scrub if needed.
-     *
-     * @param \Exception $exception
+     * Flush exception stack to Rollbar
      */
-    protected function handleException(Exception $exception)
+    public function onKernelTerminate()
     {
-        if (false === $this->reportDecisionManager->decide($exception)) {
-            return;
-        }
-
-        if (in_array(get_class($exception), $this->scrubExceptions)) {
-            /** @var FlattenException $exception */
-            $exception = FlattenException::create($exception);
-
-            $trace = $exception->getTrace();
-            foreach ($trace as $key => $item) {
-                array_walk_recursive($item['args'], function (&$value, $key, $params) {
-                    if (is_string($value) && $key = array_search($value, $params)) {
-                        $value = '%' . $key . '%';
-                    }
-                }, $this->scrubParameters);
-
-                $trace[$key] = $item;
-            }
-
-            $exception->setTrace($trace, $exception->getFile(), $exception->getLine());
-        }
-
-        $this->exception = $exception;
+        $this->exceptionReporter->flush();
     }
 
     /**
-     * Handle php error.
-     *
-     * @param int $level
-     * @param string $message
-     * @param string $file
-     * @param int $line
-     * @param string $context
-     * @return bool
+     * Flush exception stack to Rollbar
      */
-    public function handleError($level, $message, $file, $line, $context)
+    public function onConsoleTerminate()
     {
-        if (error_reporting() & $level &&
-            $this->errorLevel & $level &&
-            true === $this->reportDecisionManager->decide(new ErrorException($message, 0, $level, $file, $line))
-        ) {
-            if ($this->request) {
-                $_SERVER['HTTP_REQUEST_CONTENT'] = $this->request->getContent();
-            }
-            $this->rollbarNotifier->report_php_error($level, $message, $file, $line);
-            unset($_SERVER['HTTP_REQUEST_CONTENT']);
-        }
-
-        if ($this->previousErrorHandler) {
-            return call_user_func($this->previousErrorHandler, $level, $message, $file, $line, $context);
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Get current user info.
-     *
-     * @return null|array
-     */
-    public function getUserData()
-    {
-        if ($this->securityContext->getToken() && $this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
-            $userData = array();
-            $user = $this->securityContext->getToken()->getUser();
-            if (!$user) {
-                return null;
-            }
-            if (method_exists($user, 'getId')) {
-                $userData['id'] = $user->getId();
-            } else {
-                // id is required
-                $userData['id'] = $user->getUsername();
-            }
-            $userData['username'] = $user->getUsername();
-            if (method_exists($user, 'getEmail')) {
-                $userData['email'] = $user->getEmail();
-            }
-
-            return $userData;
-        }
-
-        return null;
-    }
-
-    /**
-     * Flush errors on halt.
-     */
-    public function flush()
-    {
-        $error = error_get_last();
-        if (!is_null($error)) {
-            switch ($error['type']) {
-                case E_ERROR:
-                    $this->rollbarNotifier->report_php_error($error['type'], $error['message'], $error['file'], $error['line']);
-                    break;
-            }
-        }
-
-        $this->rollbarNotifier->flush();
+        $this->exceptionReporter->flush();
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="staffim_rollbar.rollbar_listener.class">Staffim\RollbarBundle\EventListener\RollbarListener</parameter>
+        <parameter key="staffim_rollbar.rollbar_reporter.class">Staffim\RollbarBundle\RollbarReporter</parameter>
         <parameter key="staffim_rollbar.default_report_voter.class">Staffim\RollbarBundle\Voter\DefaultReportVoter</parameter>
         <parameter key="staffim_rollbar.report_decision_manager.class">Staffim\RollbarBundle\ReportDecisionManager</parameter>
         <parameter key="staffim_rollbar.http_exception_voter.class">Staffim\RollbarBundle\Voter\HttpExceptionVoter</parameter>
@@ -16,6 +17,11 @@
 
     <services>
         <service id="staffim_rollbar.rollbar_listener" class="%staffim_rollbar.rollbar_listener.class%">
+            <argument type="service" id="staffim_rollbar.rollbar_reporter"/>
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+         <service id="staffim_rollbar.rollbar_reporter" class="%staffim_rollbar.rollbar_reporter.class%">
             <argument type="service" id="staffim_rollbar.rollbar"/>
             <argument type="service" id="security.context"/>
             <argument type="service" id="staffim_rollbar.report_decision_manager"/>
@@ -23,10 +29,6 @@
             <argument>%staffim_rollbar.scrub_exceptions%</argument>
             <argument>%staffim_rollbar.scrub_parameters%</argument>
             <argument>%staffim_rollbar.notify_http_exception%</argument>
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-100" />
-            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-200" />
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
-            <tag name="kernel.event_listener" event="console.exception" method="onConsoleException" />
         </service>
 
         <service id="staffim_rollbar.rollbar" class="%staffim_rollbar.rollbar.class%">

--- a/RollbarReporter.php
+++ b/RollbarReporter.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Staffim\RollbarBundle;
+
+use Exception;
+use RollbarNotifier;
+use Symfony\Component\HttpKernel\Exception\FlattenException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+class RollbarReporter
+{
+    protected $rollbarNotifier;
+    protected $securityContext;
+    protected $reportDecisionManager;
+    protected $exceptionStack;
+    protected $reportVoter;
+    protected $errorLevel;
+
+    public function __construct(
+        RollbarNotifier $rollbarNotifier,
+        SecurityContextInterface $securityContext,
+        ReportDecisionManager $reportDecisionManager,
+        $errorLevel = null,
+        array $scrubExceptions = array(),
+        array $scrubParameters = array()
+    ) {
+        $this->rollbarNotifier = $rollbarNotifier;
+        $this->securityContext = $securityContext;
+        $this->reportDecisionManager = $reportDecisionManager;
+        $this->scrubExceptions = $scrubExceptions;
+        $this->scrubParameters = $scrubParameters;
+        $this->exceptionStack = array();
+        $this->errorLevel = $errorLevel;
+
+        $this->rollbarNotifier->person_fn = array($this, 'getUserData');
+        register_shutdown_function(array($this, 'flush'));
+        $this->previousErrorHandler = set_error_handler(array($this, 'reportError'));
+    }
+
+    /**
+     * Add an exception to the stack
+     *
+     * @param  Exception $exception
+     */
+    public function report(Exception $exception)
+    {
+        if (false === $this->reportDecisionManager->decide($exception)) {
+            return;
+        }
+
+        if (in_array(get_class($exception), $this->scrubExceptions)) {
+            $exception = $this->scrubException($exception);
+        }
+
+        $this->exceptionStack[] = $exception;
+    }
+
+    /**
+     * Flush the rollbar Notifier.
+     */
+    public function flush()
+    {
+        $this->rollbarNotifier->flush();
+    }
+
+    /**
+     * Scrub Exception
+     *
+     * @return Exception
+     */
+    private function scrubException($originalException)
+    {
+        $exception = FlattenException::create($originalException);
+
+        $trace = $exception->getTrace();
+        foreach ($trace as $key => $item) {
+            array_walk_recursive($item['args'], function (&$value, $key, $params) {
+                if (is_string($value) && $key = array_search($value, $params)) {
+                    $value = '%' . $key . '%';
+                }
+            }, $this->scrubParameters);
+
+            $trace[$key] = $item;
+        }
+
+        $exception->setTrace($trace, $exception->getFile(), $exception->getLine());
+
+        return $exception;
+    }
+
+    /**
+     * Get current user info.
+     *
+     * @return null|array
+     */
+    private function getUserData()
+    {
+        if ($this->securityContext->getToken() && $this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            $userData = array();
+            $user = $this->securityContext->getToken()->getUser();
+            if (!$user) {
+                return null;
+            }
+            if (method_exists($user, 'getId')) {
+                $userData['id'] = $user->getId();
+            } else {
+                // id is required
+                $userData['id'] = $user->getUsername();
+            }
+            $userData['username'] = $user->getUsername();
+            if (method_exists($user, 'getEmail')) {
+                $userData['email'] = $user->getEmail();
+            }
+
+            return $userData;
+        }
+
+        return null;
+    }
+
+    /**
+     * Handle php error.
+     *
+     * @param int $level
+     * @param string $message
+     * @param string $file
+     * @param int $line
+     * @param string $context
+     * @return bool
+     */
+    private function reportError($level, $message, $file, $line, $context)
+    {
+        if (error_reporting() & $level &&
+            $this->errorLevel & $level &&
+            true === $this->reportDecisionManager->decide(new ErrorException($message, 0, $level, $file, $line))
+        ) {
+            if ($this->request) {
+                $_SERVER['HTTP_REQUEST_CONTENT'] = $this->request->getContent();
+            }
+            $this->rollbarNotifier->report_php_error($level, $message, $file, $line);
+            unset($_SERVER['HTTP_REQUEST_CONTENT']);
+        }
+        if ($this->previousErrorHandler) {
+            return call_user_func($this->previousErrorHandler, $level, $message, $file, $line, $context);
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The PR intoduce a new service `staffim_rollbar.rollbar_reporter`. The service can be invoked manually to report any Exception. The class also register itself as an error handler to catch PHP error. 

The listener now use this class to report Kernel and Console Exceptions. 

Fix #12 